### PR TITLE
feat: 유저 권한 수정 기능 생성

### DIFF
--- a/src/main/java/com/project/bumawiki/domain/user/entity/User.java
+++ b/src/main/java/com/project/bumawiki/domain/user/entity/User.java
@@ -4,7 +4,6 @@ import com.project.bumawiki.domain.contribute.domain.Contribute;
 import com.project.bumawiki.domain.user.entity.authority.Authority;
 import leehj050211.bsmOauth.dto.response.BsmResourceResponse;
 import lombok.*;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -45,6 +44,10 @@ public class User {
         this.enroll = resource.getStudent().getEnrolledAt();
         this.nickName = resource.getNickname();
         return this;
+    }
+
+    public void changeUserAuthority(Authority authority){
+        this.authority = authority;
     }
 
 

--- a/src/main/java/com/project/bumawiki/domain/user/presentation/UserAuthorityController.java
+++ b/src/main/java/com/project/bumawiki/domain/user/presentation/UserAuthorityController.java
@@ -1,0 +1,22 @@
+package com.project.bumawiki.domain.user.presentation;
+
+import com.project.bumawiki.domain.user.entity.authority.Authority;
+import com.project.bumawiki.domain.user.presentation.dto.UserAuthorityDto;
+import com.project.bumawiki.domain.user.service.UserAuthorityService;
+import com.project.bumawiki.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserAuthorityController {
+    private final UserAuthorityService userAuthorityService;
+    private final UserService userService;
+
+    @PutMapping("/set/authority")
+    public Authority setUserAuthority(@RequestBody final UserAuthorityDto userAuthorityDto){
+        Authority execute = userAuthorityService.execute(userAuthorityDto);
+        return execute;
+    }
+}

--- a/src/main/java/com/project/bumawiki/domain/user/presentation/dto/UserAuthorityDto.java
+++ b/src/main/java/com/project/bumawiki/domain/user/presentation/dto/UserAuthorityDto.java
@@ -1,0 +1,17 @@
+package com.project.bumawiki.domain.user.presentation.dto;
+
+import com.project.bumawiki.domain.user.entity.authority.Authority;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class UserAuthorityDto {
+
+    @NotNull
+    private String email;
+    @NotNull
+    private Authority authority;
+}

--- a/src/main/java/com/project/bumawiki/domain/user/service/UserAuthorityService.java
+++ b/src/main/java/com/project/bumawiki/domain/user/service/UserAuthorityService.java
@@ -1,0 +1,32 @@
+package com.project.bumawiki.domain.user.service;
+
+import com.project.bumawiki.domain.user.entity.User;
+import com.project.bumawiki.domain.user.entity.authority.Authority;
+import com.project.bumawiki.domain.user.entity.repository.UserRepository;
+import com.project.bumawiki.domain.user.exception.UserNotFoundException;
+import com.project.bumawiki.domain.user.presentation.dto.UserAuthorityDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserAuthorityService {
+    private final UserRepository userRepository;
+
+    public Authority execute(UserAuthorityDto userAuthorityDto) {
+        Optional<User> userFindByEmail = userRepository.findByEmail(userAuthorityDto.getEmail());
+
+        if(!userFindByEmail.isPresent()){
+            throw UserNotFoundException.EXCEPTION;
+        }
+
+        User user = userFindByEmail.get();
+        user.changeUserAuthority(userAuthorityDto.getAuthority());
+        return user.getAuthority();
+    }
+}

--- a/src/main/java/com/project/bumawiki/domain/user/service/UserLoginService.java
+++ b/src/main/java/com/project/bumawiki/domain/user/service/UserLoginService.java
@@ -9,13 +9,11 @@ import com.project.bumawiki.global.jwt.config.JwtProperties;
 import com.project.bumawiki.global.jwt.util.JwtProvider;
 import com.project.bumawiki.global.jwt.dto.TokenResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 
 @ServiceWithTransactionalReadOnly
 @RequiredArgsConstructor
-@Transactional
 public class UserLoginService {
     private final UserSignUpOrUpdateService userSignUpORUpdateService;
     private final JwtProvider jwtProvider;

--- a/src/main/java/com/project/bumawiki/domain/user/service/UserService.java
+++ b/src/main/java/com/project/bumawiki/domain/user/service/UserService.java
@@ -6,7 +6,6 @@ import com.project.bumawiki.global.annotation.ServiceWithTransactionalReadOnly;
 import com.project.bumawiki.global.jwt.config.JwtConstants;
 import com.project.bumawiki.global.jwt.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
 @ServiceWithTransactionalReadOnly
 @RequiredArgsConstructor

--- a/src/main/java/com/project/bumawiki/global/security/SecurityConfig.java
+++ b/src/main/java/com/project/bumawiki/global/security/SecurityConfig.java
@@ -1,14 +1,12 @@
 package com.project.bumawiki.global.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.bumawiki.domain.user.entity.authority.Authority;
 import com.project.bumawiki.global.error.CustomAuthenticationEntryPoint;
 import com.project.bumawiki.global.jwt.auth.JwtAuth;
 import com.project.bumawiki.global.jwt.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -43,6 +41,7 @@ public class SecurityConfig {
                 .antMatchers(PUT, "/api/docs/update/**").hasAnyAuthority("USER", "ADMIN")
                 .antMatchers(DELETE,"/api/docs/delete/**").hasAuthority("ADMIN")
                 .antMatchers(PUT,"/api/docs/update/title/**").hasAuthority("ADMIN")
+                .antMatchers(PUT,"/api/set/authority").hasAuthority("ADMIN")
                 .anyRequest().permitAll()
                 .and()
                 .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint(objectMapper))

--- a/src/test/java/com/project/bumawiki/user/UserAuthorityTest.java
+++ b/src/test/java/com/project/bumawiki/user/UserAuthorityTest.java
@@ -1,0 +1,73 @@
+package com.project.bumawiki.user;
+
+import com.project.bumawiki.domain.user.entity.User;
+import com.project.bumawiki.domain.user.entity.authority.Authority;
+import com.project.bumawiki.domain.user.entity.repository.UserRepository;
+import com.project.bumawiki.domain.user.presentation.dto.UserAuthorityDto;
+import com.project.bumawiki.domain.user.service.UserAuthorityService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserAuthorityTest {
+
+    @Mock
+    static UserRepository userRepository;
+    static User user = User.builder()
+            .id(1L)
+            .name("홍길동")
+            .email("checkbanworkwell@bssm.hs.kr")
+            .authority(Authority.USER)
+            .enroll(2022)
+            .nickName("홍길동전")
+            .contributeDocs(null)
+            .build();
+
+
+
+    @Test
+    @Order(1)
+    void setUserBanWorkWell(){
+        //given
+        UserAuthorityDto userAuthorityDto = new UserAuthorityDto(user.getEmail(), Authority.BANNED);
+        when(userRepository.findByEmail("checkbanworkwell@bssm.hs.kr")).thenReturn(Optional.ofNullable(user));
+        UserAuthorityService userBannedService = new UserAuthorityService(userRepository);
+        //when
+        Authority authority = userBannedService.execute(userAuthorityDto);
+        //then
+        Assertions.assertThat(authority).isEqualTo(Authority.BANNED);
+    }
+
+    @Test
+    @Order(2)
+    void setUserUserWell(){
+        //given
+        when(userRepository.findByEmail("checkbanworkwell@bssm.hs.kr")).thenReturn(Optional.ofNullable(user));
+        UserAuthorityDto userAuthorityDto = new UserAuthorityDto(user.getEmail(), Authority.USER);
+        UserAuthorityService userBannedService = new UserAuthorityService(userRepository);
+        //when
+        Authority authority = userBannedService.execute(userAuthorityDto);
+        //then
+        Assertions.assertThat(authority).isEqualTo(Authority.USER);
+    }
+    @Test
+    @Order(3)
+    void setUser(){
+        //given
+        when(userRepository.findByEmail("checkbanworkwell@bssm.hs.kr")).thenReturn(Optional.ofNullable(user));
+        UserAuthorityDto userAuthorityDto = new UserAuthorityDto(user.getEmail(), Authority.ADMIN);
+        UserAuthorityService userBannedService = new UserAuthorityService(userRepository);
+        //when
+        Authority authority = userBannedService.execute(userAuthorityDto);
+        //then
+        Assertions.assertThat(authority).isEqualTo(Authority.ADMIN);
+    }
+}


### PR DESCRIPTION
유저 권한 수정 기능을 추가 했습니다.

UserAuthorityService에 있는 execute에 권한을 변경한 이메일과 변경할 권한이 담긴 UserAuthorityDto를 넣으면 권한을 바꿔줍니다. 만일 없는 이메일을 보냈다면 UserNotFoundException이 발생합니다.