### PR TITLE
Refactor : 자신이 좋아하는 항목 조회 쿼리 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.6'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.6'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'com.project'
@@ -22,7 +29,7 @@ repositories {
 dependencies {
 	implementation 'org.projectlombok:lombok:1.18.22'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
+//	implementation 'org.springdoc:springdo c-openapi-ui:1.6.6'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -32,27 +39,51 @@ dependencies {
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.projectreactor:reactor-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-	implementation 'com.fasterxml.jackson.core:jackson-core:2.14.0'
-	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.0'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
-	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.14.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.0'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.14.0'
 
-	implementation 'com.github.leehj050211:bsm-oauth-java:1.0.0'
+    implementation 'com.github.leehj050211:bsm-oauth-java:1.0.0'
 
-	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
-	implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
+    implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
+
+    //querydsl 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+}
+
+//querydsl 추가
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/ThumbsUp.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/ThumbsUp.java
@@ -42,6 +42,6 @@ public class ThumbsUp {
     }
 
     public ThumbsUpResponseDto getDto() {
-        return new ThumbsUpResponseDto(docs.getTitle(), docs.getDocsType());
+        return new ThumbsUpResponseDto(docs);
     }
 }

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/collection/UserThumbsUps.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/collection/UserThumbsUps.java
@@ -9,7 +9,10 @@ import com.project.bumawiki.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/repository/CustomThumbsUpRepository.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/repository/CustomThumbsUpRepository.java
@@ -1,0 +1,10 @@
+package com.project.bumawiki.domain.thumbsUp.domain.repository;
+
+import com.project.bumawiki.domain.thumbsUp.presentation.dto.ThumbsUpResponseDto;
+import com.project.bumawiki.domain.user.entity.User;
+
+import java.util.List;
+
+public interface CustomThumbsUpRepository {
+    List<ThumbsUpResponseDto> getUserThumbsUp(User user);
+}

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/repository/CustomThumbsUpRepositoryImpl.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/repository/CustomThumbsUpRepositoryImpl.java
@@ -24,7 +24,6 @@ public class CustomThumbsUpRepositoryImpl implements CustomThumbsUpRepository {
                 .from(thumbsUp)
                 .leftJoin(docs)
                 .on(thumbsUp.user.eq(user))
-                .fetchJoin()
                 .distinct()
                 .fetch();
     }

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/repository/CustomThumbsUpRepositoryImpl.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/repository/CustomThumbsUpRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.project.bumawiki.domain.thumbsUp.domain.repository;
+
+import com.project.bumawiki.domain.thumbsUp.presentation.dto.ThumbsUpResponseDto;
+import com.project.bumawiki.domain.user.entity.User;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.project.bumawiki.domain.docs.domain.QDocs.*;
+import static com.project.bumawiki.domain.thumbsUp.domain.QThumbsUp.*;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomThumbsUpRepositoryImpl implements CustomThumbsUpRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ThumbsUpResponseDto> getUserThumbsUp(User user) {
+        return jpaQueryFactory.select(Projections.constructor(ThumbsUpResponseDto.class, docs))
+                .from(thumbsUp)
+                .leftJoin(docs)
+                .on(thumbsUp.user.eq(user))
+                .fetchJoin()
+                .distinct()
+                .fetch();
+    }
+}

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/repository/ThumbsUpRepository.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/domain/repository/ThumbsUpRepository.java
@@ -1,7 +1,0 @@
-package com.project.bumawiki.domain.thumbsUp.domain.repository;
-
-import com.project.bumawiki.domain.thumbsUp.domain.ThumbsUp;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ThumbsUpRepository extends JpaRepository<ThumbsUp, Long> {
-}

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/presentation/dto/ThumbsUpResponseDto.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/presentation/dto/ThumbsUpResponseDto.java
@@ -1,6 +1,7 @@
 package com.project.bumawiki.domain.thumbsUp.presentation.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.project.bumawiki.domain.docs.domain.Docs;
 import com.project.bumawiki.domain.docs.domain.type.DocsType;
 
 public class ThumbsUpResponseDto {
@@ -10,8 +11,8 @@ public class ThumbsUpResponseDto {
     @JsonProperty
     private final DocsType docsType;
 
-    public ThumbsUpResponseDto(String title, DocsType docsType) {
-        this.title = title;
-        this.docsType = docsType;
+    public ThumbsUpResponseDto(Docs docs) {
+        this.title = docs.getTitle();
+        this.docsType = docs.getDocsType();
     }
 }

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/service/ThumbsUpInformationService.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/service/ThumbsUpInformationService.java
@@ -1,8 +1,10 @@
 package com.project.bumawiki.domain.thumbsUp.service;
 
 import com.project.bumawiki.domain.thumbsUp.domain.collection.UserThumbsUps;
+import com.project.bumawiki.domain.thumbsUp.domain.repository.CustomThumbsUpRepository;
 import com.project.bumawiki.domain.thumbsUp.exception.NoDocsYouThumbsUpException;
 import com.project.bumawiki.domain.thumbsUp.presentation.dto.ThumbsUpResponseDto;
+import com.project.bumawiki.domain.user.UserFacade;
 import com.project.bumawiki.domain.user.entity.User;
 import com.project.bumawiki.domain.user.entity.repository.UserRepository;
 import com.project.bumawiki.domain.user.exception.UserNotFoundException;
@@ -12,32 +14,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ThumbsUpInformationService {
 
-    private final UserRepository userRepository;
+    private final CustomThumbsUpRepository customThumbsUpRepository;
 
-    private static void validateThumbsUps(User user, UserThumbsUps userThumbsUps) {
-        if (userThumbsUps == null ||
-                user.getUserThumbsUps().getThumbsUpsCount() == 0) {
-            throw NoDocsYouThumbsUpException.EXCEPTION;
-        }
-    }
-
-    @Transactional(readOnly = true)
     public List<ThumbsUpResponseDto> getThumbsUpList() {
-        Long userId = SecurityUtil.getCurrentUserWithLogin().getId();
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
-
-        UserThumbsUps userThumbsUps = user.getUserThumbsUps();
-
-        validateThumbsUps(user, userThumbsUps);
-
-        return userThumbsUps.getList();
+//        User user = SecurityUtil.getCurrentUserOrNotLogin();
+//
+//        return customThumbsUpRepository.getUserThumbsUp(user);
+        return null;
     }
 }
 

--- a/src/main/java/com/project/bumawiki/domain/thumbsUp/service/ThumbsUpInformationService.java
+++ b/src/main/java/com/project/bumawiki/domain/thumbsUp/service/ThumbsUpInformationService.java
@@ -24,10 +24,9 @@ public class ThumbsUpInformationService {
     private final CustomThumbsUpRepository customThumbsUpRepository;
 
     public List<ThumbsUpResponseDto> getThumbsUpList() {
-//        User user = SecurityUtil.getCurrentUserOrNotLogin();
-//
-//        return customThumbsUpRepository.getUserThumbsUp(user);
-        return null;
+        User user = SecurityUtil.getCurrentUserOrNotLogin();
+
+        return customThumbsUpRepository.getUserThumbsUp(user);
     }
 }
 

--- a/src/main/java/com/project/bumawiki/domain/user/UserFacade.java
+++ b/src/main/java/com/project/bumawiki/domain/user/UserFacade.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 public class UserFacade {
     private final UserRepository userRepository;
 
-    @Nullable
     public User getCurrentUser() {
         User currentUserWithLogin = SecurityUtil
                 .getCurrentUserOrNotLogin();

--- a/src/main/java/com/project/bumawiki/global/jwt/config/JwtConstants.java
+++ b/src/main/java/com/project/bumawiki/global/jwt/config/JwtConstants.java
@@ -17,6 +17,4 @@ public enum JwtConstants {
 
 
     public final String message;
-
-
 }

--- a/src/main/java/com/project/bumawiki/global/querydsl/QueryDslConfig.java
+++ b/src/main/java/com/project/bumawiki/global/querydsl/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.project.bumawiki.global.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class QueryDslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/project/bumawiki/global/security/auth/AuthDetailsService.java
+++ b/src/main/java/com/project/bumawiki/global/security/auth/AuthDetailsService.java
@@ -19,5 +19,4 @@ public class AuthDetailsService implements UserDetailsService {
                 .map(AuthDetails::new)
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
     }
-
 }


### PR DESCRIPTION
QueryDsl 도입을 통해 fetch()를 사용하여서 쿼리를 한 번만 날려서 조회하도록 변경했습니다. 쿼리 실행 개수가 기본 3개 + (자신이 좋아하는 Docs의 수)에서 2개로 실행 수가 줄었습니다. 

Close #31 