### PR TITLE
DocsServiceTest 테스트코드 리팩토링

### DIFF
--- a/src/main/java/com/project/bumawiki/domain/docs/implementation/DocsCreator.java
+++ b/src/main/java/com/project/bumawiki/domain/docs/implementation/DocsCreator.java
@@ -19,7 +19,7 @@ public class DocsCreator {
 
 	public void create(Docs docs, User user, String contents) {
 		docsRepository.save(docs);
-		versionDocsRepository.save(
+		VersionDocs versionDocs = versionDocsRepository.save(
 			new VersionDocs(
 				0,
 				docs,
@@ -27,6 +27,7 @@ public class DocsCreator {
 				user
 			)
 		);
+		docsUpdater.updateModifiedAt(docs, versionDocs.getCreatedAt());
 	}
 
 	public void createVersionDocs(Docs docs, User user, String contents) {

--- a/src/main/java/com/project/bumawiki/domain/user/domain/User.java
+++ b/src/main/java/com/project/bumawiki/domain/user/domain/User.java
@@ -17,6 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -31,6 +32,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
 	@OneToMany(
 		mappedBy = "user",
 		fetch = FetchType.LAZY,
@@ -38,19 +44,10 @@ public class User {
 		orphanRemoval = true)
 	@Builder.Default
 	private final List<ThumbsUp> thumbsUps = new ArrayList<>();
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
+	@Email
 	@Size(max = 32)
 	@Column(unique = true, length = 32)
 	private String email;
-
-	@Size(max = 16)
-	@NotNull
-	@Column(length = 16)
-	private String name;
 
 	@Column(length = 8)
 	private Integer enroll;
@@ -62,6 +59,10 @@ public class User {
 	@Column(length = 16)
 	@Enumerated(EnumType.STRING)
 	private Authority authority;
+	@NotNull
+	@Size(max = 16)
+	@Column(length = 16)
+	private String name;
 
 	public List<ThumbsUpResponseDto> getList() {
 		return this.thumbsUps

--- a/src/main/java/com/project/bumawiki/global/config/s3/S3Bucket.java
+++ b/src/main/java/com/project/bumawiki/global/config/s3/S3Bucket.java
@@ -10,4 +10,7 @@ import lombok.Getter;
 public class S3Bucket {
 	@Value("${aws.s3.bucket}")
 	private String s3Bucket;
+
+	@Value("${aws.s3.read-url}")
+	private String readUrl;
 }

--- a/src/main/java/com/project/bumawiki/global/config/s3/S3Config.java
+++ b/src/main/java/com/project/bumawiki/global/config/s3/S3Config.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -19,13 +18,25 @@ class S3Config {
 	@Value("${aws.s3.secret-key}")
 	private String secretKey;
 
+	@Value("${aws.s3.region}")
+	private String region;
+
+	@Value("${aws.s3.end-point-url}")
+	private String endPointUrl;
+
 	@Bean
 	AmazonS3 amazonS3Client() {
 		return AmazonS3ClientBuilder.standard()
 			.withCredentials(
 				new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))
 			)
-			.withRegion(Regions.AP_NORTHEAST_2)
+			// .withRegion(Regions.AP_NORTHEAST_2)
+			.withEndpointConfiguration(
+				new AmazonS3ClientBuilder.EndpointConfiguration(
+					endPointUrl,
+					region
+				)
+			)
 			.build();
 	}
 }

--- a/src/main/java/com/project/bumawiki/global/s3/implement/ImageCreator.java
+++ b/src/main/java/com/project/bumawiki/global/s3/implement/ImageCreator.java
@@ -1,4 +1,4 @@
-package com.project.bumawiki.global.s3.service.implement;
+package com.project.bumawiki.global.s3.implement;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -36,7 +36,7 @@ public class ImageCreator {
 			throw new S3SaveException();
 		}
 
-		return amazonS3.getUrl(s3Bucket.getS3Bucket(), fileName).toString();
+		return s3Bucket.getReadUrl() + fileName;
 	}
 
 	private String createFileName(MultipartFile multipartFile) {

--- a/src/main/java/com/project/bumawiki/global/s3/service/CommandImageService.java
+++ b/src/main/java/com/project/bumawiki/global/s3/service/CommandImageService.java
@@ -3,7 +3,7 @@ package com.project.bumawiki.global.s3.service;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.project.bumawiki.global.s3.service.implement.ImageCreator;
+import com.project.bumawiki.global.s3.implement.ImageCreator;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -57,6 +57,9 @@ aws:
     bucket: ${S3_BUCKET}
     access-key: ${S3_ACCESSKEY}
     secret-key: ${S3_SECRET}
+    region: ${S3_REGION}
+    end-point-url: ${S3_ENDPOINT_URL}
+    read-url: ${S3_READ_URL}
 
 server:
   port: 8080

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -54,6 +54,9 @@ bsm:
 aws:
   s3:
     bucket: ${S3_BUCKET}
+    region: ${S3_REGION}
+    end-point-url: ${S3_ENDPOINT_URL}
+    read-url: ${S3_READ_URL}
     access-key: ${S3_ACCESSKEY}
     secret-key: ${S3_SECRET}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -59,6 +59,9 @@ aws:
     bucket: ${S3_BUCKET}
     access-key: ${S3_ACCESSKEY}
     secret-key: ${S3_SECRET}
+    region: ${S3_REGION}
+    end-point-url: ${S3_ENDPOINT_URL}
+    read-url: ${S3_READ_URL}
 
 image:
   path: ${SAVING_URL}

--- a/src/test/java/com/project/bumawiki/domain/docs/service/CommandDocsServiceTest.java
+++ b/src/test/java/com/project/bumawiki/domain/docs/service/CommandDocsServiceTest.java
@@ -151,7 +151,7 @@ class CommandDocsServiceTest extends ServiceTest {
 		String name = FixtureGenerator.getDefaultStringBuilder().ofLength(3).sample();
 		User user = getSavedUserWithOutThumbsUp(name);
 		Docs docs = getSavedNotStudentDocs(name);
-		String contents =FixtureGenerator.getDefaultStringBuilder().sample();
+		String contents = FixtureGenerator.getDefaultStringBuilder().sample();
 		VersionDocs versionDocs = getSavedVersionDocs(docs, user);
 
 		// when, then

--- a/src/test/java/com/project/bumawiki/domain/docs/service/CommandDocsServiceTest.java
+++ b/src/test/java/com/project/bumawiki/domain/docs/service/CommandDocsServiceTest.java
@@ -9,14 +9,12 @@ import java.util.List;
 import org.junit.jupiter.api.RepeatedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import net.jqwik.api.Arbitraries;
-
 import com.project.bumawiki.domain.docs.domain.Docs;
 import com.project.bumawiki.domain.docs.domain.VersionDocs;
 import com.project.bumawiki.domain.docs.domain.repository.DocsRepository;
 import com.project.bumawiki.domain.docs.domain.repository.VersionDocsRepository;
 import com.project.bumawiki.domain.docs.domain.type.DocsType;
-import com.project.bumawiki.domain.docs.presentation.dto.response.DocsPopularResponseDto;
+import com.project.bumawiki.domain.thumbsup.domain.ThumbsUp;
 import com.project.bumawiki.domain.thumbsup.domain.repository.ThumbsUpRepository;
 import com.project.bumawiki.domain.user.domain.User;
 import com.project.bumawiki.domain.user.domain.repository.UserRepository;
@@ -24,6 +22,8 @@ import com.project.bumawiki.global.error.exception.BumawikiException;
 import com.project.bumawiki.global.error.exception.ErrorCode;
 import com.project.bumawiki.global.service.FixtureGenerator;
 import com.project.bumawiki.global.service.ServiceTest;
+
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
 
 class CommandDocsServiceTest extends ServiceTest {
 	@Autowired
@@ -42,81 +42,89 @@ class CommandDocsServiceTest extends ServiceTest {
 	@RepeatedTest(REPEAT_COUNT)
 	void 문서_생성() {
 		//given
-		Docs docs = getDocs();
-		User user = getSavedUserWithOutThumbsUp();
+		Docs docs = FixtureGenerator.getDefaultDocsBuilder().sample();
+		User user = FixtureGenerator.getDefaultUserBuilder().sample();
+		userRepository.save(user);
 		String contents = fixtureGenerator.giveMeOne(String.class);
 
 		//when
 		commandDocsService.create(docs, user, contents);
 
 		//then
-		assertAll(
-			() -> assertThat(docsRepository.findById(docs.getId()).get()).isEqualTo(docs),
-			() -> assertThat(versionDocsRepository.findByDocs(docs).get(0).getContents()).isEqualTo(contents)
-		);
+		assertAll(() -> assertThat(docsRepository.findById(docs.getId()).get()).isEqualTo(docs),
+			() -> assertThat(versionDocsRepository.findByDocs(docs).get(0).getContents()).isEqualTo(contents));
 	}
 
 	@RepeatedTest(REPEAT_COUNT)
 	void 같은_이름_문서_생성_실패() {
 		// given
-		String title = getTitle();
-		String contents = fixtureGenerator.giveMeOne(String.class);
-		getSavedDocs(title);
-		Docs savingDocs = getDocs(title);
-		User user = getSavedUserWithOutThumbsUp();
+		String title = FixtureGenerator.getDefaultStringBuilder().ofMaxLength(32).sample();
+		String contents = FixtureGenerator.getDefaultStringBuilder().sample();
+
+		Docs docs = FixtureGenerator.getDefaultDocsBuilder().set(javaGetter(Docs::getTitle), title).sample();
+
+		docsRepository.save(docs);
+
+		Docs savingDocs = FixtureGenerator.getDefaultDocsBuilder().set(javaGetter(Docs::getTitle), title).sample();
+
+		User user = FixtureGenerator.getDefaultUserBuilder().sample();
+		userRepository.save(user);
 
 		// when
 		BumawikiException exception = assertThrows(BumawikiException.class,
-			() -> commandDocsService.create(savingDocs, user, contents)
-		);
+			() -> commandDocsService.create(savingDocs, user, contents));
 
 		// then
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DOCS_TITLE_ALREADY_EXIST);
 	}
 
-
-
 	@RepeatedTest(REPEAT_COUNT)
 	void 문서_업데이트() {
 		// given
-		User user = getSavedUserWithOutThumbsUp();
-		Docs docs = getSavedDocsNotReadonly();
+		User user = FixtureGenerator.getDefaultUserBuilder().sample();
+		userRepository.save(user);
+		Docs docs = getDocsNotDocsType(List.of(DocsType.READONLY)).sample();
+		docsRepository.save(docs);
+
 		String contents = FixtureGenerator.getDefaultStringBuilder().sample();
-		VersionDocs versionDocs = getSavedVersionDocs(docs, user);
+		VersionDocs versionDocs = getFisrtVersionDocs(docs, user);
+		versionDocsRepository.save(versionDocs);
 
 		// when
 		commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion());
 
 		// then
 		assertAll(
-			() -> assertThat(
-				versionDocsRepository.findFirstByDocsOrderByVersionDesc(docs).getContents()
-			).isEqualTo(contents),
-			() -> assertThat(versionDocsRepository.count()).isEqualTo(2)
-		);
+			() -> assertThat(versionDocsRepository.findFirstByDocsOrderByVersionDesc(docs).getContents()).isEqualTo(
+				contents), () -> assertThat(versionDocsRepository.count()).isEqualTo(2));
 	}
 
 	@RepeatedTest(REPEAT_COUNT)
 	void 문서_삭제() {
 		// given
-		Docs docs = getSavedDocs();
-		User user = getSavedUserWithOutThumbsUp();
-		getSavedThumbsUpList(docs, user);
+		Docs docs = FixtureGenerator.getDefaultDocsBuilder().sample();
+		docsRepository.save(docs);
+
+		User user = FixtureGenerator.getDefaultUserBuilder().sample();
+		userRepository.save(user);
+
+		List<ThumbsUp> thumbsUpList = FixtureGenerator.getDefaultThumbsUpBuilder(docs, user).sampleList(5);
+
+		thumbsUpRepository.saveAll(thumbsUpList);
 
 		// when
 		commandDocsService.delete(docs.getId());
 
 		// then
-		assertAll(
-			() -> assertThat(docsRepository.findById(docs.getId())).isEmpty(),
-			() -> assertThat(thumbsUpRepository.count()).isZero()
-		);
+		assertAll(() -> assertThat(docsRepository.findById(docs.getId())).isEmpty(),
+			() -> assertThat(thumbsUpRepository.count()).isZero());
 	}
 
 	@RepeatedTest(REPEAT_COUNT)
 	void 문서_타입_업데이트() {
 		// given
-		Docs docs = getSavedDocs();
+		Docs docs = FixtureGenerator.getDefaultDocsBuilder().sample();
+		docsRepository.save(docs);
 		DocsType docsType = fixtureGenerator.giveMeBuilder(DocsType.class)
 			.setPostCondition("$", DocsType.class, it -> !it.equals(docs.getDocsType()))
 			.sample();
@@ -132,15 +140,18 @@ class CommandDocsServiceTest extends ServiceTest {
 	void 일반문서_중_본인이름_포함_시_문서_업데이트_실패() {
 		// given
 		String name = FixtureGenerator.getDefaultStringBuilder().ofLength(3).sample();
-		User user = getSavedUserWithOutThumbsUp(name);
-		Docs docs = getSavedNotStudentDocs(name);
+		User user = FixtureGenerator.getDefaultUserBuilder().set(javaGetter(User::getName), name).sample();
+		userRepository.save(user);
+		Docs docs = getDocsNotDocsType(List.of(DocsType.READONLY, DocsType.STUDENT)).set(javaGetter(Docs::getTitle),
+			name).sample();
+		docsRepository.save(docs);
 		String contents = FixtureGenerator.getDefaultStringBuilder().sample();
-		VersionDocs versionDocs = getSavedVersionDocs(docs, user);
+		VersionDocs versionDocs = getFisrtVersionDocs(docs, user);
+		versionDocsRepository.save(versionDocs);
 
 		// when, then
 		BumawikiException exception = assertThrows(BumawikiException.class,
-			() -> commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion())
-		);
+			() -> commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion()));
 
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CANNOT_CHANGE_YOUR_DOCS);
 	}
@@ -149,15 +160,21 @@ class CommandDocsServiceTest extends ServiceTest {
 	void 학생문서_중_본인문서_업데이트_실패() {
 		// given
 		String name = FixtureGenerator.getDefaultStringBuilder().ofLength(3).sample();
-		User user = getSavedUserWithOutThumbsUp(name);
-		Docs docs = getSavedNotStudentDocs(name);
-		String contents =FixtureGenerator.getDefaultStringBuilder().sample();
-		VersionDocs versionDocs = getSavedVersionDocs(docs, user);
+		User user = FixtureGenerator.getDefaultUserBuilder().set(javaGetter(User::getName), name)
+			.setNotNull(javaGetter(User::getEnroll)).sample();
+		userRepository.save(user);
+		Docs docs = FixtureGenerator.getDefaultDocsBuilder()
+			.set(javaGetter(Docs::getDocsType), DocsType.STUDENT)
+			.set(javaGetter(Docs::getTitle), name)
+			.set(javaGetter(Docs::getEnroll), user.getEnroll()).sample();
+		docsRepository.save(docs);
+		String contents = FixtureGenerator.getDefaultStringBuilder().sample();
+		VersionDocs versionDocs = getFisrtVersionDocs(docs, user);
+		versionDocsRepository.save(versionDocs);
 
 		// when, then
 		BumawikiException exception = assertThrows(BumawikiException.class,
-			() -> commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion())
-		);
+			() -> commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion()));
 
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CANNOT_CHANGE_YOUR_DOCS);
 	}
@@ -165,15 +182,22 @@ class CommandDocsServiceTest extends ServiceTest {
 	@RepeatedTest(REPEAT_COUNT)
 	void 읽기전용_문서_업데이트_실패() {
 		// given
-		User user = getSavedUserWithOutThumbsUp();
-		Docs docs = getSavedDocsReadonly();
+		User user = FixtureGenerator.getDefaultUserBuilder().sample();
+		userRepository.save(user);
+
+		Docs docs = FixtureGenerator.getDefaultDocsBuilder()
+			.set(javaGetter(Docs::getDocsType), DocsType.READONLY)
+			.sample();
+
+		docsRepository.save(docs);
+
 		String contents = FixtureGenerator.getDefaultStringBuilder().sample();
-		VersionDocs versionDocs = getSavedVersionDocs(docs, user);
+		VersionDocs versionDocs = getFisrtVersionDocs(docs, user);
+		versionDocsRepository.save(versionDocs);
 
 		// when
 		BumawikiException exception = assertThrows(BumawikiException.class,
-			() -> commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion())
-		);
+			() -> commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion()));
 
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NO_UPDATABLE_DOCS);
 	}
@@ -181,15 +205,20 @@ class CommandDocsServiceTest extends ServiceTest {
 	@RepeatedTest(REPEAT_COUNT)
 	void 버전_불일치_문서_업데이트_실패() {
 		// given
-		User user = getSavedUserWithOutThumbsUp();
-		Docs docs = getSavedDocsNotReadonly();
+		User user = FixtureGenerator.getDefaultUserBuilder().sample();
+		userRepository.save(user);
+
+		Docs docs = getDocsNotDocsType(List.of(DocsType.READONLY)).sample();
+
+		docsRepository.save(docs);
+
 		String contents = FixtureGenerator.getDefaultStringBuilder().sample();
-		VersionDocs versionDocs = getSavedVersionDocs(docs, user);
+		VersionDocs versionDocs = getFisrtVersionDocs(docs, user);
+		versionDocsRepository.save(versionDocs);
 
 		// when
 		BumawikiException exception = assertThrows(BumawikiException.class,
-			() -> commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion() + 1)
-		);
+			() -> commandDocsService.update(user, docs.getTitle(), contents, versionDocs.getVersion() + 1));
 
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DOCS_CONFLICTED);
 	}
@@ -197,8 +226,12 @@ class CommandDocsServiceTest extends ServiceTest {
 	@RepeatedTest(REPEAT_COUNT)
 	void 문서_이름_수정() {
 		//given
-		Docs savedDocs = getSavedDocs();
-		String newTitle = getStringWithout(savedDocs.getTitle());
+		Docs savedDocs = FixtureGenerator.getDefaultDocsBuilder().sample();
+		docsRepository.save(savedDocs);
+
+		String newTitle = FixtureGenerator.getDefaultStringBuilder()
+			.excludeChars(savedDocs.getTitle().toCharArray())
+			.sample();
 
 		//when
 		commandDocsService.titleUpdate(savedDocs.getTitle(), newTitle);
@@ -210,145 +243,50 @@ class CommandDocsServiceTest extends ServiceTest {
 	@RepeatedTest(REPEAT_COUNT)
 	void 있는_문서_이름_수정_실패() {
 		//given
-		String title = getTitle();
-		getSavedDocs(title);
-		Docs updatingDocs = getSavedDocs(getStringWithout(title));
+		String title = FixtureGenerator.getDefaultStringBuilder().ofMaxLength(32).sample();
+		;
+
+		Docs docs = FixtureGenerator.getDefaultDocsBuilder().set(javaGetter(Docs::getTitle), title).sample();
+
+		docsRepository.save(docs);
 		//when, then
 		BumawikiException exception = assertThrows(BumawikiException.class,
-			() -> commandDocsService.titleUpdate(updatingDocs.getTitle(), title)
-		);
+			() -> commandDocsService.titleUpdate(docs.getTitle(), title));
 
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DOCS_TITLE_ALREADY_EXIST);
-	}
-
-	private static String getTitle() {
-		return FixtureGenerator.getDefaultStringBuilder().ofMaxLength(32).sample();
-	}
-
-	private static String getStringWithout(String title) {
-		String newTitle = getTitle();
-		while (title.equals(newTitle)) {
-			newTitle = getTitle();
-		}
-
-		return newTitle;
-	}
-
-	private Docs getDocs() {
-		return FixtureGenerator.getDefaultDocsBuilder().sample();
 	}
 
 	@RepeatedTest(REPEAT_COUNT)
 	void 문서_충돌_해결() {
 		// given
-		Docs docs = getSavedDocs();
-		User user = getSavedUserWithOutThumbsUp();
-		VersionDocs versionDocs = getSavedVersionDocs(docs, user);
+		Docs docs = FixtureGenerator.getDefaultDocsBuilder().sample();
+		docsRepository.save(docs);
+
+		User user = FixtureGenerator.getDefaultUserBuilder().sample();
+		userRepository.save(user);
+
+		VersionDocs versionDocs = getFisrtVersionDocs(docs, user);
+		versionDocsRepository.save(versionDocs);
 		String contents = FixtureGenerator.getDefaultStringBuilder().sample();
 
 		// when
 		commandDocsService.solveConflict(docs.getTitle(), contents, versionDocs.getVersion(), user);
 
 		// then
-		assertThat(
-			versionDocsRepository.findFirstByDocsOrderByVersionDesc(docs).getVersion()
-		).isEqualTo(versionDocs.getVersion() + 1);
+		assertThat(versionDocsRepository.findFirstByDocsOrderByVersionDesc(docs).getVersion()).isEqualTo(
+			versionDocs.getVersion() + 1);
 	}
 
-	@RepeatedTest(REPEAT_COUNT)
-	void 좋아요_내림차순_문서_전체_조회() {
-		// given
-		User user = userRepository.save(
-			FixtureGenerator.getDefaultUserBuilder()
-				.sample()
-		);
-		List<Docs> docs = docsRepository.saveAll(
-			FixtureGenerator.getDefaultDocsBuilder()
-				.sampleList(5)
-		);
-
-		for (Docs doc : docs) {
-			thumbsUpRepository.saveAll(
-				FixtureGenerator.getDefaultThumbsUpBuilder(doc, user)
-					.sampleList(Arbitraries.integers().between(1, 30).sample())
-			);
-		}
-
-		// when
-		List<DocsPopularResponseDto> list = queryDocsService.readByThumbsUpsDesc();
-
-		// then
-		assertThat(
-			thumbsUpRepository.findByDocs_Id(docsRepository.findByTitle(list.get(0).title()).get().getId())
-		).hasSize(list.get(0).thumbsUpsCounts().intValue());
-	}
-
-	private void getSavedThumbsUpList(Docs docs, User user) {
-		thumbsUpRepository.saveAll(
-			FixtureGenerator.getDefaultThumbsUpBuilder(docs, user)
-				.sampleList(5)
-		);
-	}
-
-	private Docs getDocs(String title) {
+	private ArbitraryBuilder<Docs> getDocsNotDocsType(List<DocsType> docsTypes) {
 		return FixtureGenerator.getDefaultDocsBuilder()
-			.set(javaGetter(Docs::getTitle), title)
+			.setPostCondition(javaGetter(Docs::getDocsType), DocsType.class,
+				it -> docsTypes.stream().noneMatch(it::equals));
+	}
+
+	private VersionDocs getFisrtVersionDocs(Docs docs, User user) {
+		return FixtureGenerator.getDefaultVersionDocsBuilder(docs, user)
+			.set(javaGetter(VersionDocs::getVersion), 0)
 			.sample();
 	}
 
-	private Docs getSavedDocs() {
-		return docsRepository.save(getDocs());
-	}
-
-	private Docs getSavedDocsNotReadonly() {
-		return docsRepository.save(
-			FixtureGenerator.getDefaultDocsBuilder()
-				.setPostCondition(javaGetter(Docs::getDocsType), DocsType.class, it -> it != DocsType.READONLY)
-				.sample()
-		);
-	}
-
-	private Docs getSavedDocsReadonly() {
-		return docsRepository.save(
-			FixtureGenerator.getDefaultDocsBuilder()
-				.set(javaGetter(Docs::getDocsType), DocsType.READONLY)
-				.sample()
-		);
-	}
-
-	private Docs getSavedNotStudentDocs(String name) {
-		return docsRepository.save(
-			FixtureGenerator.getDefaultDocsBuilder()
-				.setPostCondition(javaGetter(Docs::getDocsType), DocsType.class, it -> it != DocsType.STUDENT)
-				.set("title", name + FixtureGenerator.getDefaultStringBuilder().ofMaxLength(29).sample())
-				.sample()
-		);
-	}
-
-	private Docs getSavedDocs(String title) {
-		return docsRepository.save(getDocs(title));
-	}
-
-	private VersionDocs getSavedVersionDocs(Docs docs, User user) {
-		return versionDocsRepository.save(
-			FixtureGenerator.getDefaultVersionDocsBuilder(docs, user)
-				.set(javaGetter(VersionDocs::getVersion), 0)
-				.sample()
-		);
-	}
-
-	private User getSavedUserWithOutThumbsUp() {
-		return userRepository.save(
-			FixtureGenerator.getDefaultUserBuilder()
-				.sample()
-		);
-	}
-
-	private User getSavedUserWithOutThumbsUp(String name) {
-		return userRepository.save(
-			FixtureGenerator.getDefaultUserBuilder()
-				.set(javaGetter(User::getName), name)
-				.sample()
-		);
-	}
 }

--- a/src/test/java/com/project/bumawiki/domain/docs/service/QueryDocsServiceTest.java
+++ b/src/test/java/com/project/bumawiki/domain/docs/service/QueryDocsServiceTest.java
@@ -146,12 +146,12 @@ class QueryDocsServiceTest extends ServiceTest {
 
 		userRepository.save(user);
 
-		List<Docs> docsList = FixtureGenerator.getDefaultDocsBuilder().sampleList(30);
-
-		docsRepository.saveAll(docsList);
-
 		DocsType randomDocsType = Arbitraries.of(DocsType.class).sample();
 
+		List<Docs> docsList = FixtureGenerator.getDefaultDocsBuilder().sampleList(30);
+		docsList.add(FixtureGenerator.getDefaultDocsBuilder()
+			.set(javaGetter(Docs::getDocsType), randomDocsType).sample());
+		docsRepository.saveAll(docsList);
 		// when
 		List<Docs> findDocsList = queryDocsService.findByDocsTypeOrderByEnroll(randomDocsType);
 
@@ -160,7 +160,7 @@ class QueryDocsServiceTest extends ServiceTest {
 			() -> assertThat(docsList.containsAll(findDocsList)).isTrue(),
 			() -> assertThat(
 				findDocsList.stream().map(Docs::getDocsType).collect(Collectors.toSet()).size()
-			).isEqualTo(0),
+			).isEqualTo(1),
 			() -> assertThat(
 				findDocsList.stream().map(Docs::getDocsType).collect(Collectors.toSet()).contains(randomDocsType)
 			).isTrue()
@@ -212,6 +212,7 @@ class QueryDocsServiceTest extends ServiceTest {
 		userRepository.save(user);
 
 		List<Docs> docsList = FixtureGenerator.getDefaultDocsBuilder()
+			.setNotNull(javaGetter(Docs::getLastModifiedAt))
 			.sampleList(20);
 
 		docsRepository.saveAll(docsList);

--- a/src/test/java/com/project/bumawiki/global/service/FixtureGenerator.java
+++ b/src/test/java/com/project/bumawiki/global/service/FixtureGenerator.java
@@ -51,7 +51,7 @@ public class FixtureGenerator {
 			.set(javaGetter(ThumbsUp::getDocs), docs);
 	}
 
-	public static StringArbitrary getDefaultStringBuilder(){
+	public static StringArbitrary getDefaultStringBuilder() {
 		return Arbitraries.strings()
 			.ascii()
 			.ofMinLength(1);

--- a/src/test/java/com/project/bumawiki/global/service/FixtureGenerator.java
+++ b/src/test/java/com/project/bumawiki/global/service/FixtureGenerator.java
@@ -1,0 +1,59 @@
+package com.project.bumawiki.global.service;
+
+import static com.navercorp.fixturemonkey.api.experimental.JavaGetterMethodPropertySelector.*;
+
+import java.util.Collections;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.arbitraries.StringArbitrary;
+
+import com.project.bumawiki.domain.docs.domain.Docs;
+import com.project.bumawiki.domain.docs.domain.VersionDocs;
+import com.project.bumawiki.domain.thumbsup.domain.ThumbsUp;
+import com.project.bumawiki.domain.user.domain.User;
+import com.project.bumawiki.domain.user.domain.authority.Authority;
+
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+
+public class FixtureGenerator {
+
+	private static final FixtureMonkey fixtureGenerator = FixtureMonkey.builder()
+		.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+		.plugin(new JakartaValidationPlugin())
+		.build();
+
+	public static ArbitraryBuilder<Docs> getDefaultDocsBuilder() {
+		return fixtureGenerator.giveMeBuilder(Docs.class)
+			.setNull(javaGetter(Docs::getId))
+			.set(javaGetter(Docs::getVersionDocs), Collections.emptyList());
+	}
+
+	public static ArbitraryBuilder<VersionDocs> getDefaultVersionDocsBuilder(Docs docs, User user) {
+		return fixtureGenerator.giveMeBuilder(VersionDocs.class)
+			.set(javaGetter(VersionDocs::getUser), user)
+			.set(javaGetter(VersionDocs::getDocs), docs);
+	}
+
+	public static ArbitraryBuilder<User> getDefaultUserBuilder() {
+		return fixtureGenerator.giveMeBuilder(User.class)
+			.setNull(javaGetter(User::getId))
+			.set(javaGetter(User::getAuthority), Authority.USER)
+			.setNull(javaGetter(User::getThumbsUps));
+	}
+
+	public static ArbitraryBuilder<ThumbsUp> getDefaultThumbsUpBuilder(Docs docs, User user) {
+		return fixtureGenerator.giveMeBuilder(ThumbsUp.class)
+			.setNull(javaGetter(ThumbsUp::getId))
+			.set(javaGetter(ThumbsUp::getUser), user)
+			.set(javaGetter(ThumbsUp::getDocs), docs);
+	}
+
+	public static StringArbitrary getDefaultStringBuilder(){
+		return Arbitraries.strings()
+			.ascii()
+			.ofMinLength(1);
+	}
+}

--- a/src/test/java/com/project/bumawiki/global/service/ServiceTest.java
+++ b/src/test/java/com/project/bumawiki/global/service/ServiceTest.java
@@ -2,7 +2,6 @@ package com.project.bumawiki.global.service;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.RepeatedTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -54,6 +54,9 @@ aws:
     bucket: test-bucket
     access-key: test-access-key
     secret-key: test-secret-key
+    region: asdf
+    end-point-url: asdf
+    read-url: asdf
 
 server:
   port: 8080


### PR DESCRIPTION
🔨 Describe

> CommandDocsServiceTest, QueryDocsServiceTest를 리팩토링 했습니다

- `@Test`와 `@RepeatedTest(REPEAT_COUNT)` 중 후자를 선택했습니다. FIxture Monkey의 장점 중 하나인 엣지 케이스를 찾기 위함입니다.
- `FixtureGenerator` 클래스로 따로 빼서 정적 메서드로 사용하도록 했습니다. `@Autowired`를 사용해서 굳이 주입을 하지 않고 코드의 재사용성을 높이기 위함입니다.

✅ Tasks

- [x] `@RepeatedTest(REPEAT_COUNT)`로 통일하기
- [x] `FixtureGenerator` 클래스로 Fixture 생성하는 코드 대체하기